### PR TITLE
Переключение версии SDK на 20.1100 в ветке rc-20.1100

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "saby-types",
-   "version": "20.1000.0",
+   "version": "20.1100.0",
    "repository": {
       "type": "git",
       "url": "git@github.com:saby/Types.git"
@@ -51,11 +51,11 @@
       "report-dir": "./artifacts/coverage"
    },
    "devDependencies": {
-      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-20.1000",
-      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-20.1000",
-      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-20.1000",
-      "saby-units": "git+https://github.com/saby/Units.git#rc-20.1000",
-      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-20.1000",
-      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-20.1000"
+      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-20.1100",
+      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-20.1100",
+      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-20.1100",
+      "saby-units": "git+https://github.com/saby/Units.git#rc-20.1100",
+      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-20.1100",
+      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-20.1100"
    }
 }


### PR DESCRIPTION
Мерж создан сборкой "http://ci.sbis.ru/job/sdk_cheker/5963/".